### PR TITLE
Allow image access from Databroker

### DIFF
--- a/docs/user/how-to/run-scan.rst
+++ b/docs/user/how-to/run-scan.rst
@@ -1,8 +1,13 @@
 Running a scan
 ==================
 
-* Start the interactive bluesky environment. This is best done within the same network as the docker-compose environment which can be achieved by running: :code:`docker run --net tomoscan_default -it tomoscan`
-* Start the phoebus screen to monitor the scan's progress. Navigate to the display folder and run :code:`./startOvervirew.sh`
+* Start the interactive bluesky environment. It is important to mount the output directory and run the container within the same network as the docker-compose environment. This can be achieved by running:
+
+.. code-block:: bash
+
+    docker run --net tomoscan_default --mount type=bind,source="$(pwd)"/data,target=/out -it tomoscan
+
+* Start the phoebus screen to monitor the scan's progress. Navigate to the display folder and run :code:`./startOverview.sh`
 
 There are two scan modes which are explained below. Outputs from the scan are saved to the data directory.
 

--- a/src/tomoscan/ophyd_inter_setup.py
+++ b/src/tomoscan/ophyd_inter_setup.py
@@ -33,7 +33,7 @@ class MyDetector(SingleTrigger, AreaDetector):
         MyHDF5Plugin,
         "HDF1:",
         write_path_template="/out/%Y/%m/%d/",
-        read_path_template="/data/%Y/%m/%d/",  # Where bluesky container mount data
+        read_path_template="/out/%Y/%m/%d/",  # Where bluesky container mount data
     )
 
 
@@ -113,6 +113,8 @@ prefix = "ADT:USER1:"
 det = MyDetector(prefix, name="det")
 det.hdf1.create_directory.put(-5)
 det.hdf1.warmup()
+
+det.hdf1.kind = 3  # config | normal, required to include images in run documents
 
 det.cam.stage_sigs["image_mode"] = "Multiple"
 det.cam.stage_sigs["acquire_time"] = 0.05

--- a/src/tomoscan/ophyd_inter_setup.py
+++ b/src/tomoscan/ophyd_inter_setup.py
@@ -132,8 +132,8 @@ RE = RunEngine()
 bec = BestEffortCallback()
 # db = Broker.named("temp")  # This creates a temporary database
 # db = Broker.named("mongo")  # Connects to MongoDB database
-# catalog = databroker.catalog["mongo"]
-catalog = databroker.temp().v2
+catalog = databroker.catalog["mongo"]
+# catalog = databroker.temp().v2
 
 # Send all metadata/data captured to the BestEffortCallback.
 RE.subscribe(bec)


### PR DESCRIPTION
A small change which sets the "kind" of the ophyd hdf plugin meaning that the images are included in the run documents and accessible through the databroker. 
I have also edited the documents such that the instructions include the mounting of the output volume to the Bluesky Docker container.