### PR TITLE
Addition of explicit Docker volume for mongoDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 version: "3.8"
+
+volumes:
+  mongodata:
+    name: tomoscan_mongodbdata
+
 services:
   motor-sim:
     image: sim-pmac
@@ -121,6 +126,8 @@ services:
     image: mongo
     ports:
       - "27017:27017"
+    volumes:
+      - mongodata:/data/db
     logging:
       driver: "gelf"
       options:


### PR DESCRIPTION
By default the mongoDB docker container creates a new docker volume each time it is instantiated, these volumes have randomly generated names. This means that each time the docker compose environment is restarted the data from previous runs is not reloaded.

This PR simply adds an explicit named docker volume to the  docker compose file which means that previous data will be accessible even when the mongoDB container is restarted.